### PR TITLE
Add training placeholders and requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch
+numpy
+timm
+einops
+scikit-learn

--- a/src/energy_train.py
+++ b/src/energy_train.py
@@ -1,0 +1,20 @@
+import argparse
+import logging
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Energy-based training placeholder")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of epochs")
+    return parser.parse_args()
+
+
+def main(args=None):
+    args = get_args() if args is None else args
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Starting energy-based training for %d epochs", args.epochs)
+    # TODO: Implement energy-based training
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mae_pretrain.py
+++ b/src/mae_pretrain.py
@@ -1,0 +1,20 @@
+import argparse
+import logging
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="MAE pretraining placeholder")
+    parser.add_argument("--config", type=str, default=None, help="Path to config file")
+    return parser.parse_args()
+
+
+def main(args=None):
+    args = get_args() if args is None else args
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Starting MAE pretraining with config: %s", args.config)
+    # TODO: Implement MAE pretraining
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stream_main.py
+++ b/src/stream_main.py
@@ -1,0 +1,20 @@
+import argparse
+import logging
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Streaming discovery placeholder")
+    parser.add_argument("--input", type=str, default=None, help="Stream input source")
+    return parser.parse_args()
+
+
+def main(args=None):
+    args = get_args() if args is None else args
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Running streaming pipeline on: %s", args.input)
+    # TODO: Implement streaming discovery
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/train_arcface.py
+++ b/src/train_arcface.py
@@ -1,0 +1,20 @@
+import argparse
+import logging
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="ArcFace training placeholder")
+    parser.add_argument("--dataset", type=str, default=None, help="Training dataset")
+    return parser.parse_args()
+
+
+def main(args=None):
+    args = get_args() if args is None else args
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Training ArcFace model on dataset: %s", args.dataset)
+    # TODO: Implement ArcFace training
+    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set up a `src/` directory with entry point scripts
- provide simple argument parsers for MAE pretraining, ArcFace training, energy-based training, and streaming mode
- specify minimal package dependencies in `requirements.txt`

## Testing
- `pytest -q`
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fd7fa9c7083219536738c19fc20fe